### PR TITLE
Reinitialize the result_buffer - Fix bug where "streaks" were shown on output Bitmaps

### DIFF
--- a/adafruit_bitmapsaver.py
+++ b/adafruit_bitmapsaver.py
@@ -91,6 +91,7 @@ def _write_pixels(output_file, pixel_source, palette):
                     color >>= 8
                     buffer_index += 1
         else:
+            result_buffer = bytearray(2048)
             data = pixel_source.fill_row(y - 1, result_buffer)
             for i in range(width):
                 pixel565 = (data[i * 2] << 8) + data[i * 2 + 1]

--- a/adafruit_bitmapsaver.py
+++ b/adafruit_bitmapsaver.py
@@ -91,7 +91,6 @@ def _write_pixels(output_file, pixel_source, palette):
                     color >>= 8
                     buffer_index += 1
         else:
-            result_buffer = bytearray(2048)
             data = pixel_source.fill_row(y - 1, result_buffer)
             for i in range(width):
                 pixel565 = (data[i * 2] << 8) + data[i * 2 + 1]

--- a/adafruit_bitmapsaver.py
+++ b/adafruit_bitmapsaver.py
@@ -99,6 +99,8 @@ def _write_pixels(output_file, pixel_source, palette):
                     row_buffer[buffer_index] = b & 0xFF
                     buffer_index += 1
         output_file.write(row_buffer)
+        for i in range(width * 2):
+            result_buffer[i] = 0
         gc.collect()
 
 


### PR DESCRIPTION
When using the displayio's `fill_area` function, it does not copy anything for pixels where no Group, TileGrid, or VectorIO is present.  In this library, this was causing previous values in the result_buffer to be recopied to the output bitmap file whenever a "un-owned" pixel is observed.

This reinitializes the `result_buffer` to be sure that any "un-owned" pixels are made black in the output bitmap file.

Resolves issue:
https://github.com/adafruit/Adafruit_CircuitPython_BitmapSaver/issues/8