### PR TITLE
Update how board.DISPLAY is checked

### DIFF
--- a/adafruit_bitmapsaver.py
+++ b/adafruit_bitmapsaver.py
@@ -168,7 +168,7 @@ def save_pixels(
     :param palette: the Palette to use for looking up colors in the bitmap
     """
     if not pixel_source:
-        if not hasattr(board, "DISPLAY"):
+        if not getattr(board, "DISPLAY", None):
             raise ValueError("Second argument must be a Bitmap or Display")
         pixel_source = board.DISPLAY
 


### PR DESCRIPTION
Historically, boards with no built-in display have not had a `board.DISPLAY` property.

Soon, with https://github.com/adafruit/circuitpython/pull/10028, any board with displayio will have a `board.DISPLAY` property. This property will be `None` if no display is configured, or a truthy non-`None` value if a display is configured (including dynamically at runtime).

This revised check will work on both old and new circuitpython versions.