### PR TITLE
Flip byteorder

### DIFF
--- a/adafruit_bitmapsaver.py
+++ b/adafruit_bitmapsaver.py
@@ -145,7 +145,7 @@ def _write_pixels(
             result_buffer = bytearray(2048)
             data = pixel_source.fill_row(y - 1, result_buffer)
             for i in range(width):
-                pixel565 = (data[i * 2] << 8) + data[i * 2 + 1]
+                pixel565 = (data[i * 2 + 1] << 8) + data[i * 2]
                 for b in _rgb565_to_bgr_tuple(pixel565):
                     row_buffer[buffer_index] = b & 0xFF
                     buffer_index += 1


### PR DESCRIPTION
When working with `framebufferio.FramebufferDisplay` sources, the byte order of 16-bit pixel data was flipped, causing major color errors. This update simply changes the byteorder.

This fix has been tested on the Adafruit Fruit Jam using the following code:

``` python
import displayio
import supervisor
from terminalio import FONT
import vectorio

from adafruit_bitmapsaver import save_pixels
from adafruit_display_text.label import Label
from adafruit_fruitjam.peripherals import request_display_config

BAR_COLORS = (
    0x000000,
    0x444444,
    0x888888,
    0xcccccc,
    0xffffff
)
CIRCLE_COLOR = 0xff0000
TEXT_COLOR = 0xffffff

# initialize display
request_display_config(320, 240)
display = supervisor.runtime.display
display.auto_refresh = False

# create root group
group = displayio.Group()
display.root_group = group

# draw bars
for i, color in enumerate(BAR_COLORS):
    palette = displayio.Palette(1)
    palette[0] = color
    group.append(vectorio.Rectangle(
        pixel_shader=palette,
        width=display.width//len(BAR_COLORS),
        height=display.height,
        x=display.width//len(BAR_COLORS)*i,
    ))

# draw circle
palette = displayio.Palette(1)
palette[0] = CIRCLE_COLOR
group.append(vectorio.Circle(
    pixel_shader=palette, radius=min(display.width, display.height)//4,
    x=display.width//2, y=display.height//2,
))

# draw text
group.append(Label(
    font=FONT, text="Hello, World!",
    anchor_point=(.5, .5),
    anchored_position=(display.width//2, display.height//2),
))

# update display
display.refresh()

print("Taking Screenshot... ")
save_pixels("/sd/screenshot.bmp", display)
print("Screenshot Saved")
```

Before:
![screenshot-before.bmp](https://github.com/user-attachments/files/22219922/screenshot-before.bmp)

After:
![screenshot-after.bmp](https://github.com/user-attachments/files/22219937/screenshot-after.bmp)

_Note: This update has not been tested on other display sources. It is possible that the source needs to be tested in some manner to decide the byte order._

Fixes https://github.com/adafruit/Adafruit_CircuitPython_BitmapSaver/issues/36